### PR TITLE
make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+clean:
+	find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
+	find . -type f -name "*.pyc" -delete 2>/dev/null || true
+	rm -rf .pytest_cache htmlcov .coverage .coverage.xml .mypy_cache 2>/dev/null || true
+
 lint:
 	poetry run flake8 .
 

--- a/README.md
+++ b/README.md
@@ -44,13 +44,14 @@ Apache 2
 
 # Testing
 
-To run tests, run the following command:
+To run tests, run the following commands:
 
 ```bash
+make clean
 make test
 ```
 
-This will run all tests, linting, and formatting checks. Test coverage is tracked and must be at least 80%.
+The `make clean` command removes all artifacts from previous build runs. The `make test` command will run all tests, linting, and formatting checks. Test coverage is tracked and must be at least 80%.
 
 # Acknowledgments
 

--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,12 @@
+# Agents Development Guide
+
+## Testing
+
+Before running tests, always clean the environment:
+
+```bash
+make clean
+make test
+```
+
+This ensures that no cached artifacts interfere with test execution.


### PR DESCRIPTION
Closes #49

Add a target "clean" to the makefile that cleans all artifacts of previous makefile runs (e.g. *.pyc files, .venv directory, etc).
Add to your agents.md that you need to run "make clean" before running "make test"